### PR TITLE
Enable option to add Volume, VolumeMount to devlake Deployment - critical for SSL certificate #310

### DIFF
--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -205,9 +205,21 @@ spec:
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.lake.volumeMounts }}
+          volumeMounts:
+            {{- range $volumeMount := .Values.lake.volumeMounts }}
+            - {{- $volumeMount | toYaml | nindent 14 }}
+            {{- end }}
+          {{- end }}
           {{- with .Values.lake.containerSecurityContext }}
           securityContext:
           {{- toYaml . | nindent 12 }}
+      {{- end }}
+      {{- if .Values.lake.volumes }}
+      volumes:
+        {{- range $volume := .Values.lake.volumes }}
+        - {{- $volume | toYaml | nindent 10 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.lake.hostNetwork }}
       hostNetwork: true
@@ -225,5 +237,3 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
   {{- end }}
-
-

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -231,7 +231,8 @@ spec:
       {{- end }}
       {{- with .Values.lake.affinity }}
       affinity:
-      {{- toYaml . | nindent 8 }}      {{- end }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.lake.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -232,6 +232,9 @@ spec:
       {{- with .Values.lake.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
+
+
+
       {{- end }}
       {{- with .Values.lake.tolerations }}
       tolerations:

--- a/charts/devlake/templates/deployments.yaml
+++ b/charts/devlake/templates/deployments.yaml
@@ -231,12 +231,10 @@ spec:
       {{- end }}
       {{- with .Values.lake.affinity }}
       affinity:
-      {{- toYaml . | nindent 8 }}
-
-
-
-      {{- end }}
+      {{- toYaml . | nindent 8 }}      {{- end }}
       {{- with .Values.lake.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
   {{- end }}
+
+

--- a/charts/devlake/values.yaml
+++ b/charts/devlake/values.yaml
@@ -252,6 +252,21 @@ lake:
   deployment:
     extraLabels: {}
 
+  # Additional volumes to include in the Pod. Example:
+  #
+  # volumes:
+  #   - name: my-volume
+  #     configMap: my-config-map
+  volumes: []
+
+  # Additional volume mounts to include in the Container. Example:
+  #
+  # volumeMounts:
+  #   - name: test-volume
+  #     mountPath: /opt/test_folder
+  #     subPath: test_file.yaml
+  volumeMounts: []
+
 ui:
   image:
     repository: devlake.docker.scarf.sh/apache/devlake-config-ui


### PR DESCRIPTION
The devlake [Deployment](https://github.com/apache/incubator-devlake-helm-chart/blob/1b9a97f4a4c103d62c0f9a4ccdf9afc39b9c5307/charts/devlake/templates/deployments.yaml#L121) does not expose `Volumes`, `VolumeMounts`.

These are required e.g. to mount a CA Certificate to establish a secure SSL connection.
Our policies only allow SSL connections to Azure MySQL Server. I would love to contribute to Apache DevLAke and add the PR myself.

There are several GH issues related to SSL and the current limitations
- https://github.com/apache/incubator-devlake/issues/7928
- https://github.com/apache/incubator-devlake/issues/8121